### PR TITLE
add ability to set a "direct" ZIP download link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 .idea
+vendor/
+composer\.lock

--- a/wp-dependencies-example.json
+++ b/wp-dependencies-example.json
@@ -32,5 +32,12 @@
     "branch": "develop",
     "optional": true,
     "token": null
+  },
+  {
+    "name": "Test Direct Plugin Download",
+    "host": "direct",
+    "slug": "test-direct-plugin/test-plugin.php",
+    "uri": "https://direct-download.com/path/to.zip",
+    "optional": true
   }
 ]

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -146,6 +146,9 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 					case( 'wordpress' ):
 						$download_link = 'https://downloads.wordpress.org/plugin/' . basename( $owner_repo ) . '.zip';
 						break;
+					case( 'direct' ):
+						$download_link = filter_var( $uri, FILTER_VALIDATE_URL ) ? $uri : null;
+						break;
 				}
 
 				$this->config[ $slug ]['download_link'] = $download_link;


### PR DESCRIPTION
Heya Andy/Matt,

Just wanted to share this with you. It's a simple addition to your system, whereby it makes it trivial to apply a dependency using a URI directly without relying on any source control providers.  I chose the host type "direct", but if that's not the most apt, perhaps another could be used.

Cheers.
Paul.