### PR TITLE
Set default fallback timeout if filter doesn't return anything

### DIFF
--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -424,8 +424,10 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 				 * @param string $notice['source'] Plugin slug of calling plugin.
 				 * @return string|int              Dismissal timeout in days.
 				 */
-				$timeout     = '-' . apply_filters( 'wp_dependency_timeout', '7', $notice['source'] );
-				$dismissible = isset( $notice['slug'] )
+				$default_timeout = '7';
+				$timeout         = '-' . apply_filters( 'wp_dependency_timeout', '7', $notice['source'] );
+				$timeout         = $timeout ? $timeout : $default_timeout;
+				$dismissible     = isset( $notice['slug'] )
 					? 'dependency-installer-' . dirname( $notice['slug'] ) . $timeout
 					: null;
 				if ( class_exists( '\PAnd' ) && ! \PAnD::is_admin_notice_active( $dismissible ) ) {

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -425,8 +425,9 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 				 * @return string|int              Dismissal timeout in days.
 				 */
 				$default_timeout = '7';
-				$timeout         = '-' . apply_filters( 'wp_dependency_timeout', '7', $notice['source'] );
+				$timeout         = apply_filters( 'wp_dependency_timeout', $default_timeout, $notice['source'] );
 				$timeout         = $timeout ? $timeout : $default_timeout;
+				$timeout         = '-' . (string) absint( $timeout );
 				$dismissible     = isset( $notice['slug'] )
 					? 'dependency-installer-' . dirname( $notice['slug'] ) . $timeout
 					: null;


### PR DESCRIPTION
Fixes https://github.com/afragen/wp-dependency-installer/issues/21 (i think)