### PR TITLE
More granular support for WordPress.org plugins

### DIFF
--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -166,7 +166,13 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 							$download_link = add_query_arg( 'access_token', $dependency['token'], $download_link );
 						}
 					case 'wordpress':
-						$download_link = 'https://downloads.wordpress.org/plugin/' . basename( $owner_repo ) . '.zip';
+						$wp_slug = basename( $owner_repo );
+						if ( $dependency[ 'branch' ] == 'latest' ) {
+							$download_link = $this->getWpPluginLatestDownloadUrl( $wp_slug );
+						}
+						if ( empty( $download_link ) ) {
+							$download_link = 'https://downloads.wordpress.org/plugin/'.$wp_slug.'.zip';
+						}
 						break;
 					case 'direct':
 						$download_link = filter_var( $uri, FILTER_VALIDATE_URL );
@@ -175,6 +181,17 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 
 				$this->config[ $slug ]['download_link'] = $download_link;
 			}
+		}
+
+		/**
+		 * @param string $slug
+		 * @return string
+		 */
+		protected function getWpPluginLatestDownloadUrl( $slug ) {
+			include_once( ABSPATH.'wp-admin/includes/plugin-install.php' );
+			$pinfo = plugins_api( 'plugin_information', array( 'slug' => $slug ) );
+			return ( is_object( $pinfo ) && isset( $pinfo->download_link )
+					 && filter_var( $pinfo->download_link, FILTER_VALIDATE_URL ) ) ? $pinfo->download_link : '';
 		}
 
 		/**

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -170,6 +170,13 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 						if ( $dependency[ 'branch' ] == 'latest' ) {
 							$download_link = $this->getWpPluginLatestDownloadUrl( $wp_slug );
 						}
+						else if ( strpos( $dependency[ 'branch' ], '.' ) > 0 ) {
+							$download_link = sprintf(
+								'https://downloads.wordpress.org/plugin/%s.%s.zip',
+								$wp_slug,
+								$dependency[ 'branch' ]
+							);
+						}
 						if ( empty( $download_link ) ) {
 							$download_link = 'https://downloads.wordpress.org/plugin/'.$wp_slug.'.zip';
 						}

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -195,10 +195,15 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * @return string
 		 */
 		protected function getWpPluginLatestDownloadUrl( $slug ) {
-			include_once( ABSPATH.'wp-admin/includes/plugin-install.php' );
-			$pinfo = plugins_api( 'plugin_information', array( 'slug' => $slug ) );
-			return ( is_object( $pinfo ) && isset( $pinfo->download_link )
-					 && filter_var( $pinfo->download_link, FILTER_VALIDATE_URL ) ) ? $pinfo->download_link : '';
+			$url = get_transient( 'wp-dependency-installer-url-'.$slug );
+			if ( $url === false ) {
+				include_once( ABSPATH.'wp-admin/includes/plugin-install.php' );
+				$pinfo = plugins_api( 'plugin_information', array( 'slug' => $slug ) );
+				$url = ( is_object( $pinfo ) && isset( $pinfo->download_link )
+						 && filter_var( $pinfo->download_link, FILTER_VALIDATE_URL ) ) ? $pinfo->download_link : '';
+				set_transient( 'wp-dependency-installer-url-'.$slug, $url, DAY_IN_SECONDS );
+			}
+			return $url;
 		}
 
 		/**


### PR DESCRIPTION
Hey guys,

This pull request has 2 parts to consider:

1) Support for automatically finding the latest tag release of a wp.org plugin and using that link as the download URL instead of just defaulting to 'trunk'. The reason this is important is because many devs will push code to the trunk prior to release, so in its current form, this plugin will be installing code that may or may not be designed for production.

You can flag this by setting "latest" as the 'trunk' value for a WordPress.org plugin.

It also uses WP transients to store URL so it doesn't look them up on every request.

2) The other part adds support for installing specific versions of WordPress.org plugins. WordPress.org provides a consistent format for this and we can take advantage of that.

You can flag this by setting a version number as the 'trunk' value. If it contains a period '.', then it's flagged as a version.

Hope you find it useful! :)