### PR TITLE
Add download link filter and get_config() method

### DIFF
--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -169,6 +169,16 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 						break;
 				}
 
+				/**
+				 * Allow filtering of download link for dependency configuration.
+				 *
+				 * @since 1.4.11
+				 *
+				 * @param string $download_link Download link.
+				 * @param array  $dependency    Dependency configuration.
+				 */
+				$download_link = apply_filters( 'wp_dependency_download_link', $download_link, $dependency );
+
 				$this->config[ $slug ]['download_link'] = $download_link;
 			}
 		}
@@ -181,6 +191,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 */
 		private function get_dot_org_latest_download( $slug ) {
 			$download_link = get_site_transient( 'wpdi-' . md5( $slug ) );
+
 			if ( ! $download_link ) {
 				$url           = 'https://api.wordpress.org/plugins/info/1.1/';
 				$url           = add_query_arg(
@@ -506,6 +517,17 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 			$actions = array_merge( array( 'required-plugin' => sprintf( esc_html__( '%1$sPlugin dependency%2$s' ), '<span class="network_active">', '</span>' ) ), $actions );
 
 			return $actions;
+		}
+
+		/**
+		 * Get the configuration.
+		 *
+		 * @since 1.4.11
+		 *
+		 * @return array The configuration.
+		 */
+		public function get_config() {
+			return $this->config;
 		}
 	}
 


### PR DESCRIPTION
Allow filtering of download link for dependency configurations in new filter `wp_dependency_download_link`. Also allow config to be retrieved from class object with new public method `get_config()`.