### PR TITLE
Handle null install responses

### DIFF
--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -350,6 +350,11 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 					'status'  => 'error',
 					'message' => $result->get_error_message(),
 				);
+			} elseif ( null === $result ) ) {
+				return array(
+					'status'  => 'error',
+					'message' => esc_html__( 'Plugin download failed' ),
+				);
 			}
 
 			wp_cache_flush();

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -350,7 +350,9 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 					'status'  => 'error',
 					'message' => $result->get_error_message(),
 				);
-			} elseif ( null === $result ) {
+			}
+
+			if ( null === $result ) {
 				return array(
 					'status'  => 'error',
 					'message' => esc_html__( 'Plugin download failed' ),

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -350,7 +350,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 					'status'  => 'error',
 					'message' => $result->get_error_message(),
 				);
-			} elseif ( null === $result ) ) {
+			} elseif ( null === $result ) {
 				return array(
 					'status'  => 'error',
 					'message' => esc_html__( 'Plugin download failed' ),


### PR DESCRIPTION
Null install responses are false positives in the current logic. Sometimes the install can return a null value and this just handles that case.