### PR TITLE
Increase "Plugin dependency" label visibility

### DIFF
--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -561,7 +561,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		public function row_meta( $links, $slug ) {
 			if ( in_array( $slug, self::$required_plugins, true ) ) {
 				/* translators: %s: opening and closing span tags */
-				array_unshift( $links, sprintf( esc_html__( '%1$sPlugin dependency%2$s' ), '<strong style=" font-weight: 700; padding: 2px 5px; background: #fff; border: 2px solid #000; border-radius: 3px;">', '</strong>' ) );
+				array_unshift( $links, sprintf( esc_html__( '%1$sPlugin dependency%2$s' ), '<strong style=" font-weight: 700; padding: 2px 5px; background: #ff0; border: 2px solid #000; border-radius: 3px;">', '</strong>' ) );
 			}
 			return $links;
 		}

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -590,7 +590,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		public function row_meta( $links, $slug ) {
 			if ( in_array( $slug, self::$required_plugins, true ) ) {
 				/* translators: %s: opening and closing span tags */
-				array_unshift( $links, sprintf( esc_html__( '%1$sPlugin dependency%2$s' ), '<strong style=" font-weight: 700; padding: 2px 5px; background: #ff0; border: 2px solid #000; border-radius: 3px;">', '</strong>' ) );
+				array_unshift( $links, sprintf( esc_html__( '%1$sPlugin dependency%2$s' ), '<strong style=" font-weight: 700; padding: 2px 5px; background: #fff; border: 1px solid #ccd0d4; border-radius: 2px;">', '</strong>' ) );
 			}
 			return $links;
 		}


### PR DESCRIPTION
Some reasons for the edit:

- likewise to what has been done for local-development, I believe that the most correct position for the label is beside the **`row_meta`** links
- since a plugin can have many dependencies I think it is better to keep the label always in the same position (**first `row_meta` item**) within the plugins.php page.

![local development](https://user-images.githubusercontent.com/9614886/73029524-f99a8c00-3e37-11ea-863a-eca5d9c351c3.png)
