### PR TITLE
Dismiss label

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,22 @@ The default timeout for dismissal of a notification is 7 days. There is a filter
 ```php
 add_filter(
   'wp_dependency_timeout', function( $timeout, $source ) {
-    $timeout = $source !== basename( __DIR__ ) ? $timeout : 14;
+    $timeout = basename( __DIR__ ) !== $source ? $timeout : 14;
     return $timeout;
   }, 10, 2
+);
+```
+
+To help the end user before installation, you can also display your plugin name within dismissable notifications through the `wp_dependency_dismiss_label` filter:
+
+```php
+add_filter(
+  'wp_dependency_dismiss_label', function( $label, $source ) {
+    $label = basename(__DIR__) !== $source ? $label : __( 'My Plugin Name', 'my-plugin-domain' );
+    return $label;
+  },
+  10,
+  2
 );
 ```
 

--- a/example-plugin/test-dependency-installer.php
+++ b/example-plugin/test-dependency-installer.php
@@ -7,6 +7,7 @@
  * Version: 1.0
  * Author: Andy Fragen, Matt Gibbs
  * License: MIT
+ * Text Domain: test-dependency-installer
  * Requires WP: 5.1
  * Requires PHP: 5.6
  */
@@ -14,11 +15,28 @@
 require_once __DIR__ . '/vendor/autoload.php';
 
 WP_Dependency_Installer::instance()->run( __DIR__ );
+
+/**
+ * Increase dismissable timeout from 7 to 14 days.
+ */
 add_filter(
 	'wp_dependency_timeout',
 	function( $timeout, $source ) {
 		$timeout = basename( __DIR__ ) !== $source ? $timeout : 14;
 		return $timeout;
+	},
+	10,
+	2
+);
+
+/**
+ * Change dismissable label from [Dependency] to [Test Dependency Installer].
+ */
+add_filter(
+	'wp_dependency_dismiss_label',
+	function( $label, $source ) {
+		$label = basename(__DIR__) !== $source ? $label : __( 'Test Dependency Installer', 'test-dependency-installer' );
+		return $label;
 	},
 	10,
 	2

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -507,13 +507,13 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 				/**
 				 * Filters the dismissal notice label
 				 *
-				 * @since
+				 * @since 2.1.1
 				 *
 				 * @param  string Default dismissal notice string.
-				 * @param  array  $notice notice info of calling plugin.
+				 * @param  string $notice['source'] Plugin slug of calling plugin.
 				 * @return string Dismissal notice string.
 				 */
-				$label = apply_filters( 'wp_dependency_dismiss_label', __( 'Dependency' ), $notice );
+				$label = apply_filters( 'wp_dependency_dismiss_label', __( 'Dependency' ), $notice['source'] );
 				?>
 				<div data-dismissible="<?php echo $dismissible; ?>" class="<?php echo $status; ?> notice is-dismissible dependency-installer">
 					<p><?php echo '<strong>[' . esc_html( $label ) . ']</strong> ' . $message; ?></p>

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -504,9 +504,19 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 				if ( class_exists( '\PAnd' ) && ! \PAnD::is_admin_notice_active( $dismissible ) ) {
 					continue;
 				}
+				/**
+				 * Filters the dismissal notice label
+				 *
+				 * @since
+				 *
+				 * @param  string Default dismissal notice string.
+				 * @param  array  $notice notice info of calling plugin.
+				 * @return string Dismissal notice string.
+				 */
+				$label = apply_filters( 'wp_dependency_dismiss_label', __( 'Dependency' ), $notice );
 				?>
 				<div data-dismissible="<?php echo $dismissible; ?>" class="<?php echo $status; ?> notice is-dismissible dependency-installer">
-					<p><?php echo '<strong>[' . esc_html__( 'Dependency' ) . ']</strong> ' . $message; ?></p>
+					<p><?php echo '<strong>[' . esc_html( $label ) . ']</strong> ' . $message; ?></p>
 				</div>
 				<?php
 			}


### PR DESCRIPTION
Added the `wp_dependency_dismiss_label` filter to be able to receive additional information about the requesting plugin.

![0](https://user-images.githubusercontent.com/9614886/73128749-516dfa00-3fd4-11ea-8102-7b436eb80183.png)

![1](https://user-images.githubusercontent.com/9614886/73128748-516dfa00-3fd4-11ea-92ba-148136a05c1f.png)

```php
/**
 * Group Plugin Installer
 *
 * @author  Andy Fragen
 * @license MIT
 * @link    https://github.com/afragen/group-plugin-installer
 * @package group-plugin-installer
 */

require_once __DIR__ . '/vendor/autoload.php';
WP_Dependency_Installer::instance()->run( __DIR__ );

add_filter(
  'wp_dependency_dismiss_label',
  function( $label, $source ) {
    $label = basename(__DIR__) !== $source ? $label : __( 'Group Plugin Installer', 'group-plugin-installer' );
    return $label;
  },
  10,
  2
);
```