### PR TITLE
Helper functions

### DIFF
--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 *
 		 * @return void
 		 */
-		private function load_hooks() {
+		public function load_hooks() {
 			add_action( 'admin_init', [ $this, 'admin_init' ] );
 			add_action( 'admin_footer', [ $this, 'admin_footer' ] );
 			add_action( 'admin_notices', [ $this, 'admin_notices' ] );
@@ -118,7 +118,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		/**
 		 * Process the registered dependencies.
 		 */
-		private function apply_config() {
+		public function apply_config() {
 			foreach ( $this->config as $dependency ) {
 				$download_link = null;
 				$base          = null;
@@ -185,7 +185,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * @param  string $slug Plugin slug.
 		 * @return string $download_link
 		 */
-		private function get_dot_org_latest_download( $slug ) {
+		public function get_dot_org_latest_download( $slug ) {
 			$download_link = get_site_transient( 'wpdi-' . md5( $slug ) );
 
 			if ( ! $download_link ) {
@@ -308,7 +308,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 *
 		 * @return boolean
 		 */
-		private function is_installed( $slug ) {
+		public function is_installed( $slug ) {
 			$plugins = get_plugins();
 
 			return isset( $plugins[ $slug ] );
@@ -321,7 +321,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 *
 		 * @return bool|array false or Message.
 		 */
-		private function install( $slug ) {
+		public function install( $slug ) {
 			if ( $this->is_installed( $slug ) || ! current_user_can( 'update_plugins' ) ) {
 				return false;
 			}
@@ -384,7 +384,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 *
 		 * @return array Message.
 		 */
-		private function activate( $slug ) {
+		public function activate( $slug ) {
 			// network activate only if on network admin pages.
 			$result = is_network_admin() ? activate_plugin( $slug, null, true ) : activate_plugin( $slug );
 
@@ -408,7 +408,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 *
 		 * @return array Empty Message.
 		 */
-		private function dismiss() {
+		public function dismiss() {
 			return [
 				'status'  => 'updated',
 				'message' => '',
@@ -443,7 +443,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 *
 		 * @return bool|void
 		 */
-		private function move( $source, $destination ) {
+		public function move( $source, $destination ) {
 			if ( @rename( $source, $destination ) ) {
 				return true;
 			}
@@ -526,7 +526,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 *
 		 * @param $plugin_file Plugin file.
 		 */
-		private function hide_plugin_action_links( $plugin_file ) {
+		public function hide_plugin_action_links( $plugin_file ) {
 			add_filter( 'network_admin_plugin_action_links_' . $plugin_file, [ $this, 'unset_action_links' ] );
 			add_filter( 'plugin_action_links_' . $plugin_file, [ $this, 'unset_action_links' ] );
 			add_action(

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -600,12 +600,15 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * Get the configuration.
 		 *
 		 * @since 1.4.11
+		 * 
+		 * @param string $slug Plugin slug.
 		 *
 		 * @return array The configuration.
 		 */
-		public function get_config() {
-			return $this->config;
+		public function get_config( $slug = '' ) {
+			return isset( $this->config[ $slug ] ) ? $this->config[ $slug ] : $this->config;
 		}
+
 	}
 
 	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -230,22 +230,22 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 				if ( $this->is_installed( $slug ) ) {
 					if ( ! $is_required ) {
 						$this->notices[] = [
-							'action'  => 'activate',
-							'slug'    => $slug,
+							'action' => 'activate',
+							'slug'   => $slug,
 							/* translators: %s: Plugin name */
-							'text'    => sprintf( esc_html__( 'Please activate the %s plugin.' ), $dependency['name'] ),
-							'source'  => $dependency['source'],
+							'text'   => sprintf( esc_html__( 'Please activate the %s plugin.' ), $dependency['name'] ),
+							'source' => $dependency['source'],
 						];
 					} else {
 						$this->notices[] = $this->activate( $slug );
 					}
 				} elseif ( ! $is_required ) {
 					$this->notices[] = [
-						'action'  => 'install',
-						'slug'    => $slug,
+						'action' => 'install',
+						'slug'   => $slug,
 						/* translators: %s: Plugin name */
-						'text'    => sprintf( esc_html__( 'The %s plugin is required.' ), $dependency['name'] ),
-						'source'  => $dependency['source'],
+						'text'   => sprintf( esc_html__( 'The %s plugin is required.' ), $dependency['name'] ),
+						'source' => $dependency['source'],
 					];
 				} else {
 					$this->notices[] = $this->install( $slug );
@@ -558,7 +558,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		/**
 		 * Hide links from plugin row.
 		 *
-		 * @param $plugin_file Plugin file.
+		 * @param string $plugin_file Plugin file.
 		 */
 		public function hide_plugin_action_links( $plugin_file ) {
 			add_filter( 'network_admin_plugin_action_links_' . $plugin_file, [ $this, 'unset_action_links' ] );
@@ -600,7 +600,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * Get the configuration.
 		 *
 		 * @since 1.4.11
-		 * 
+		 *
 		 * @param string $slug Plugin slug.
 		 *
 		 * @return array The configuration.

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -223,7 +223,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 					$this->hide_plugin_action_links( $slug );
 				}
 
-				if ( is_plugin_active( $slug ) ) {
+				if ( $this->is_active( $slug ) ) {
 					continue;
 				}
 
@@ -335,6 +335,17 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 			$plugins = get_plugins();
 
 			return isset( $plugins[ $slug ] );
+		}
+
+		/**
+		 * Is dependency active?
+		 *
+		 * @param string $slug Plugin slug.
+		 *
+		 * @return boolean
+		 */
+		public function is_active( $slug ) {
+			return is_plugin_active( $slug );
 		}
 
 		/**


### PR DESCRIPTION
Related to https://github.com/afragen/wp-dependency-installer/pull/37, code refactoring to allow third-party developers to use the following functions:

```php
// Get Plugin Dependencies status.

WP_Dependency_Installer::instance()->is_installed( "github-updater/github-updater.php" );
WP_Dependency_Installer::instance()->is_active( "github-updater/github-updater.php" );
WP_Dependency_Installer::instance()->is_required( "github-updater/github-updater.php" );
WP_Dependency_Installer::instance()->is_required( [
  "name"     => "GitHub Updater",
  "host"     => "github",
  "slug"     => "github-updater/github-updater.php",
  "uri"      => "afragen/github-updater",
  "branch"   => "develop",
  "required" => true,
  "token"    => null
] );

// Get Plugin Dependencies config.

WP_Dependency_Installer::instance()->get_config( "github-updater/github-updater.php" );
WP_Dependency_Installer::instance()->get_config( );

// Custom Plugin Dependencies.

WP_Dependency_Installer::instance()->install( "github-updater/github-updater.php" );
WP_Dependency_Installer::instance()->active( "github-updater/github-updater.php" );
```

**Additional Notes:**
- restore all functions as public to allow anyone to follow their best installation strategy