### PR TITLE
Required label

### DIFF
--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -557,7 +557,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 			}
 
 			/* translators: %s: opening and closing span tags */
-			$actions = array_merge( [ 'required-plugin' => sprintf( esc_html__( '%1$sPlugin dependency%2$s' ), '<span class="network_active">', '</span>' ) ], $actions );
+			$actions = array_merge( [ 'required-plugin' => sprintf( esc_html__( '%1$sRequired Plugin%2$s' ), '<span class="network_active" style="font-variant-caps: small-caps;">', '</span>' ) ], $actions );
 
 			return $actions;
 		}


### PR DESCRIPTION
Related to https://github.com/afragen/wp-dependency-installer/pull/37, improves distinctiveness and **comprehensibility of the label** (changed from "Plugin Dependency" to "Required Plugin")

**Before:**

![label-before](https://user-images.githubusercontent.com/9614886/73592397-3df1f000-44fa-11ea-9238-1dea8242ac2e.png)

**After:**

![label-after](https://user-images.githubusercontent.com/9614886/73592398-3e8a8680-44fa-11ea-9c32-f2aab3887441.png)
