### PR TITLE
Register config

### DIFF
--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -84,15 +84,14 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * Register wp-dependencies.json
 		 *
 		 * @param string $plugin_path Path to plugin or theme calling the framework.
+		 * @param array  $config (optional) JSON config as array.
 		 */
-		public function run( $plugin_path ) {
+		public function run( $plugin_path, $config = [] ) {
 			if ( file_exists( $plugin_path . '/wp-dependencies.json' ) ) {
 				$config = file_get_contents( $plugin_path . '/wp-dependencies.json' );
-				if ( empty( $config ) ||
-					null === ( $config = json_decode( $config, true ) )
-				) {
-					return;
-				}
+				$config = json_decode( $config, true );
+			}
+			if ( ! empty( $config ) ) {
 				$this->source = basename( $plugin_path );
 				$this->load_hooks();
 				$this->register( $config );
@@ -102,7 +101,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		/**
 		 * Register dependencies (supports multiple instances).
 		 *
-		 * @param array $config JSON config as string.
+		 * @param array $config JSON config as array.
 		 */
 		public function register( $config ) {
 			foreach ( $config as $dependency ) {


### PR DESCRIPTION
Related to https://github.com/afragen/wp-dependency-installer/issues/43, adds an optional second parameter within the `run()` function to allow us to abstract from its contents.

## Example of usage:

```php
/**
 * Group Plugin Installer
 *
 * @author  Andy Fragen
 * @license MIT
 * @link    https://github.com/afragen/group-plugin-installer
 * @package group-plugin-installer
 */

$config = json_decode(<<<JSON
[
  {
    "name": "GitHub Updater",
    "host": "github",
    "slug": "github-updater/github-updater.php",
    "uri": "afragen/github-updater",
    "branch": "master",
    "optional": false,
    "token": null
  }
]
JSON
, true ); // <-- NB the comma here is only needed for a faster HEREDOC assignment

include_once( __DIR__ . '/vendor/autoload.php' );

// Install and active dependencies.
// OLD:
// WP_Dependency_Installer::instance()->source = basename( __DIR__ ); <-- 😠 bad code
// WP_Dependency_Installer::instance()->load_hooks();
// WP_Dependency_Installer::instance()->register( $config );

// NEW:
WP_Dependency_Installer::instance()->run( __DIR__, $config );
```





