### PR TITLE
Register config v2

### DIFF
--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -84,15 +84,14 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * Register wp-dependencies.json
 		 *
 		 * @param string $plugin_path Path to plugin or theme calling the framework.
+		 * @param array  $config (optional) JSON config as array.
 		 */
-		public function run( $plugin_path ) {
+		public function run( $plugin_path, $config = [] ) {
 			if ( file_exists( $plugin_path . '/wp-dependencies.json' ) ) {
 				$config = file_get_contents( $plugin_path . '/wp-dependencies.json' );
-				if ( empty( $config ) ||
-					null === ( $config = json_decode( $config, true ) )
-				) {
-					return;
-				}
+				$config = json_decode( $config, true );
+			}
+			if ( ! empty( $config ) ) {
 				$this->source = basename( $plugin_path );
 				$this->load_hooks();
 				$this->register( $config );
@@ -102,7 +101,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		/**
 		 * Register dependencies (supports multiple instances).
 		 *
-		 * @param array $config JSON config as string.
+		 * @param array $config JSON config as array.
 		 */
 		public function register( $config ) {
 			foreach ( $config as $dependency ) {

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -26,11 +26,11 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 	class WP_Dependency_Installer {
 
 		/**
-		 * Holds multiple singleton instances.
+		 * Holds singleton instance.
 		 *
-		 * @var array $instances
+		 * @var WP_Dependency_Installer $instance
 		 */
-		protected static $instances = [];
+		protected static $instance;
 
 		/**
 		 * Holds the JSON file contents.
@@ -68,27 +68,21 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		protected $notices;
 
 		/**
-		 * Multiton.
-		 *
-		 * @param string $plugin_path (optional) Path to plugin or theme calling the framework.
+		 * Singleton.
 		 */
-		public static function instance( $plugin_path = '' ) {
-			if ( ! array_key_exists( $plugin_path, self::$instances ) ) {
-				self::$instances[ $plugin_path ] = new self( $plugin_path );
+		public static function instance() {
+			if ( ! self::$instance ) {
+				self::$instance = new self();
 			}
-			return self::$instances[ $plugin_path ];
+			return self::$instance;
 		}
 
 		/**
 		 * Private constructor.
-		 *
-		 * @param string $plugin_path Path to plugin or theme calling the framework.
 		 */
-		protected function __construct( $plugin_path ) {
-			$this->plugin_path = $plugin_path;
-			$this->source      = basename( $plugin_path );
-			$this->config      = [];
-			$this->notices     = [];
+		protected function __construct() {
+			$this->config  = [];
+			$this->notices = [];
 		}
 
 		/**
@@ -110,12 +104,9 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		/**
 		 * Register wp-dependencies.json
 		 *
-		 * @param string $plugin_path (optional) Path to plugin or theme calling the framework.
+		 * @param string $plugin_path Path to plugin or theme calling the framework.
 		 */
-		public function run( $plugin_path = false ) {
-			if ( ! $plugin_path ) { // TODO: deprecate parameter in future releases?
-				$plugin_path = $this->plugin_path;
-			}
+		public function run( $plugin_path ) {
 			if ( file_exists( $plugin_path . '/wp-dependencies.json' ) ) {
 				$config = file_get_contents( $plugin_path . '/wp-dependencies.json' );
 				$config = json_decode( $config, true );
@@ -130,15 +121,10 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * Register dependencies (supports multiple instances).
 		 *
 		 * @param array  $config JSON config as array.
-		 * @param string $plugin_path (optional) Path to plugin or theme calling the framework.
+		 * @param string $plugin_path Path to plugin or theme calling the framework.
 		 */
-		public function register( $config, $plugin_path = false ) {
-			if ( ! $plugin_path ) { // TODO: deprecate parameter in future releases?
-				$plugin_path = $this->plugin_path;
-				$source      = $this->source;
-			} else {
-				$source = basename( $plugin_path );
-			}
+		public function register( $config, $plugin_path ) {
+			$source = basename( $plugin_path );
 			foreach ( $config as $dependency ) {
 				$dependency['source'] = $source;
 				$slug                 = $dependency['slug'];

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -24,12 +24,20 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 	 * Class WP_Dependency_Installer
 	 */
 	class WP_Dependency_Installer {
+
+		/**
+		 * Holds multiple singleton instances.
+		 *
+		 * @var array $instances
+		 */
+		protected static $instances = [];
+
 		/**
 		 * Holds the JSON file contents.
 		 *
 		 * @var array $config
 		 */
-		protected $config = [];
+		protected $config;
 
 		/**
 		 * Holds the current dependency's slug.
@@ -57,25 +65,30 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 *
 		 * @var array $notices
 		 */
-		protected $notices = [];
+		protected $notices;
 
 		/**
-		 * Singleton.
+		 * Multiton.
+		 *
+		 * @param string $plugin_path (optional) Path to plugin or theme calling the framework.
 		 */
-		public static function instance( $plugin_path = false ) {
-			static $instance = null;
-			if ( null === $instance ) {
-				$instance = new self( $plugin_path );
+		public static function instance( $plugin_path = '' ) {
+			if ( ! array_key_exists( $plugin_path, self::$instances ) ) {
+				self::$instances[ $plugin_path ] = new self( $plugin_path );
 			}
-
-			return $instance;
+			return self::$instances[ $plugin_path ];
 		}
 
 		/**
 		 * Private constructor.
+		 *
+		 * @param string $plugin_path Path to plugin or theme calling the framework.
 		 */
 		protected function __construct( $plugin_path ) {
 			$this->plugin_path = $plugin_path;
+			$this->source      = basename( $plugin_path );
+			$this->config      = [];
+			$this->notices     = [];
 		}
 
 		/**

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -100,7 +100,9 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * @param string $plugin_path (optional) Path to plugin or theme calling the framework.
 		 */
 		public function run( $plugin_path = false ) {
-			$plugin_path = empty( $plugin_path ) ? $this->plugin_path : $plugin_path; // TODO: deprecate parameter in future releases?
+			if ( ! $plugin_path ) { // TODO: deprecate parameter in future releases?
+				$plugin_path = $this->plugin_path;
+			}
 			if ( file_exists( $plugin_path . '/wp-dependencies.json' ) ) {
 				$config = file_get_contents( $plugin_path . '/wp-dependencies.json' );
 				$config = json_decode( $config, true );
@@ -114,11 +116,13 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		/**
 		 * Register dependencies (supports multiple instances).
 		 *
-		 * @param array $config JSON config as array.
+		 * @param array  $config JSON config as array.
 		 * @param string $plugin_path (optional) Path to plugin or theme calling the framework.
 		 */
 		public function register( $config, $plugin_path = false ) {
-			$plugin_path  = empty( $plugin_path ) ? $this->plugin_path : $plugin_path; // TODO: deprecate parameter in future releases?
+			if ( ! $plugin_path ) { // TODO: deprecate parameter in future releases?
+				$plugin_path = $this->plugin_path;
+			}
 			$this->source = basename( $plugin_path );
 			foreach ( $config as $dependency ) {
 				$dependency['source'] = $this->source;

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -100,7 +100,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * @param string $plugin_path (optional) Path to plugin or theme calling the framework.
 		 */
 		public function run( $plugin_path = false ) {
-			$plugin_path = empty( $plugin_path ) ? $this->plugin_path : $plugin_path;
+			$plugin_path = empty( $plugin_path ) ? $this->plugin_path : $plugin_path; // TODO: deprecate parameter in future releases?
 			if ( file_exists( $plugin_path . '/wp-dependencies.json' ) ) {
 				$config = file_get_contents( $plugin_path . '/wp-dependencies.json' );
 				$config = json_decode( $config, true );
@@ -118,10 +118,10 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * @param string $plugin_path (optional) Path to plugin or theme calling the framework.
 		 */
 		public function register( $config, $plugin_path = false ) {
-			$plugin_path = empty( $plugin_path ) ? $this->plugin_path : $plugin_path;
-			$source      = basename( $plugin_path );
+			$plugin_path  = empty( $plugin_path ) ? $this->plugin_path : $plugin_path; // TODO: deprecate parameter in future releases?
+			$this->source = basename( $plugin_path );
 			foreach ( $config as $dependency ) {
-				$dependency['source'] = $source;
+				$dependency['source'] = $this->source;
 				$slug                 = $dependency['slug'];
 				if ( ! isset( $this->config[ $slug ] ) || $this->is_required( $dependency ) ) {
 					$this->config[ $slug ] = $dependency;

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -122,10 +122,12 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		public function register( $config, $plugin_path = false ) {
 			if ( ! $plugin_path ) { // TODO: deprecate parameter in future releases?
 				$plugin_path = $this->plugin_path;
+				$source      = $this->source;
+			} else {
+				$source = basename( $plugin_path );
 			}
-			$this->source = basename( $plugin_path );
 			foreach ( $config as $dependency ) {
-				$dependency['source'] = $this->source;
+				$dependency['source'] = $source;
 				$slug                 = $dependency['slug'];
 				if ( ! isset( $this->config[ $slug ] ) || $this->is_required( $dependency ) ) {
 					$this->config[ $slug ] = $dependency;

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -39,6 +39,13 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		protected $current_slug;
 
 		/**
+		 * Holds the calling plugin/theme path.
+		 *
+		 * @var string $source
+		 */
+		protected $plugin_path;
+
+		/**
 		 * Holds the calling plugin/theme slug.
 		 *
 		 * @var string $source


### PR DESCRIPTION
This pull should maintain backward compatibility with previous versions:

```php
// Next major release.
WP_Dependency_Installer::instance( __DIR__ )->register( $config );
WP_Dependency_Installer::instance( __DIR__ )->run();

// Backwards compatibility releases.
WP_Dependency_Installer::instance()->register( $config, __DIR__ );
WP_Dependency_Installer::instance()->run( __DIR__ );
```

In particular:

- it adds the class variable `$plugin_path` inside the new protected singleton constructor
- should solve all the problems mentioned here https://github.com/afragen/wp-dependency-installer/issues/43

---

**Edit:** we have chosen to maintain backward compatibility with the other singleton classes, for a proof of concept of the multiton class you can refer to the following commit: https://github.com/afragen/wp-dependency-installer/pull/46/commits/6ee379b432b50afce4b17135ce2a637ee5e9455c