### PR TITLE
Cleaner install conditions

### DIFF
--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -248,27 +248,17 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 				if ( $this->is_active( $slug ) ) {
 					continue;
 				} elseif ( $this->is_installed( $slug ) ) {
-					if ( ! $is_required ) {
-						$this->notices[] = [
-							'action'  => 'activate',
-							'slug'    => $slug,
-							/* translators: %s: Plugin name */
-							'message' => sprintf( esc_html__( 'Please activate the %s plugin.' ), $dependency['name'] ),
-							'source'  => $dependency['source'],
-						];
-					} else {
+					if ( $is_required ) {
 						$this->notices[] = $this->activate( $slug );
+					} else {
+						$this->notices[] = $this->activate_notice( $slug );
 					}
-				} elseif ( ! $is_required ) {
-					$this->notices[] = [
-						'action'  => 'install',
-						'slug'    => $slug,
-						/* translators: %s: Plugin name */
-						'message' => sprintf( esc_html__( 'The %s plugin is required.' ), $dependency['name'] ),
-						'source'  => $dependency['source'],
-					];
 				} else {
-					$this->notices[] = $this->install( $slug );
+					if ( $is_required ) {
+						$this->notices[] = $this->install( $slug );
+					} else {
+						$this->notices[] = $this->install_notice( $slug );
+					}
 				}
 			}
 		}
@@ -433,6 +423,24 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		}
 
 		/**
+		 * Get install plugin notice.
+		 *
+		 * @param string $slug Plugin slug.
+		 *
+		 * @return array Admin notice.
+		 */
+		public function install_notice( $slug ) {
+			$dependency = $this->config[ $slug ];
+			return [
+				'action' => 'install',
+				'slug'   => $slug,
+				/* translators: %s: Plugin name */
+				'message'   => sprintf( esc_html__( 'The %s plugin is required.' ), $dependency['name'] ),
+				'source' => $dependency['source'],
+			];
+		}
+
+		/**
 		 * Activate dependency.
 		 *
 		 * @param string $slug Plugin slug.
@@ -455,6 +463,24 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 				/* translators: %s: Plugin name */
 				'message' => sprintf( esc_html__( '%s has been activated.' ), $this->config[ $slug ]['name'] ),
 				'source'  => $this->config[ $slug ]['source'],
+			];
+		}
+
+		/**
+		 * Get activate plugin notice.
+		 *
+		 * @param string $slug Plugin slug.
+		 *
+		 * @return array Admin notice.
+		 */
+		public function activate_notice( $slug ) {
+			$dependency = $this->config[ $slug ];
+			return [
+				'action' => 'activate',
+				'slug'   => $slug,
+				/* translators: %s: Plugin name */
+				'message'   => sprintf( esc_html__( 'Please activate the %s plugin.' ), $dependency['name'] ),
+				'source' => $dependency['source'],
 			];
 		}
 


### PR DESCRIPTION
Related to https://github.com/afragen/wp-dependency-installer/pull/40#issuecomment-586349603, add `install_notice` and `activate_notice` functions to improve code readability