### PR TITLE
Put the registration of the JSON file in it's own function

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ You may use `required` or `optional` as interchangable opposites. If a plugin is
 If you want to programmatically add dependencies you can send an associative array directly to
 
 ```php
-WP_Dependency_Installer::instance()->register( $config )
+WP_Dependency_Installer::instance()->register( $config, __DIR__ );
+WP_Dependency_Installer::instance()->run( __DIR__ );
 ```
 
 where `$config` is an associative array as in identical format as `json_decode( wp-dependencies.json content )`

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -103,21 +103,35 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		}
 
 		/**
-		 * Register wp-dependencies.json
+		 * Let's get going.
+		 * First load data from wp-dependencies.json if present.
+		 * Then load hooks needed to run.
 		 *
 		 * @param string $plugin_path Path to plugin or theme calling the framework.
 		 */
-		public function run( $plugin_path ) {
-			if ( file_exists( $plugin_path . '/wp-dependencies.json' ) ) {
-				$config = file_get_contents( $plugin_path . '/wp-dependencies.json' );
-				$config = json_decode( $config, true );
-			}
-			if ( ! empty( $config ) ) {
+		public function run( $plugin_path, $config = false ) {
+			$config = $this->register_json_file_data( $plugin_path );
+			if ( ! $config ) {
 				$this->register( $config, $plugin_path );
 			}
 			if ( ! empty( $this->config ) ) {
 				$this->load_hooks();
 			}
+		}
+
+		/**
+		 * Register data from wp-dependencies.json file.
+		 *
+		 * @return bool|array $config
+		 */
+		public function register_json_file_data( $plugin_path ) {
+			$config = false;
+			if ( file_exists( $plugin_path . '/wp-dependencies.json' ) ) {
+				$config = file_get_contents( $plugin_path . '/wp-dependencies.json' );
+				$config = json_decode( $config, true );
+			}
+
+			return $config;
 		}
 
 		/**

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -109,9 +109,9 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 *
 		 * @param string $plugin_path Path to plugin or theme calling the framework.
 		 */
-		public function run( $plugin_path, $config = false ) {
+		public function run( $plugin_path ) {
 			$config = $this->register_json_file_data( $plugin_path );
-			if ( ! $config ) {
+			if ( ! empty( $config ) ) {
 				$this->register( $config, $plugin_path );
 			}
 			if ( ! empty( $this->config ) ) {
@@ -125,7 +125,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * @return bool|array $config
 		 */
 		public function register_json_file_data( $plugin_path ) {
-			$config = false;
+			$config = [];
 			if ( file_exists( $plugin_path . '/wp-dependencies.json' ) ) {
 				$config = file_get_contents( $plugin_path . '/wp-dependencies.json' );
 				$config = json_decode( $config, true );

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 *
 		 * @return bool|array $config
 		 */
-		public function register_json_file( $plugin_path ) {
+		private function register_json_file( $plugin_path ) {
 			$config = [];
 			if ( file_exists( $plugin_path . '/wp-dependencies.json' ) ) {
 				$config = file_get_contents( $plugin_path . '/wp-dependencies.json' );

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -110,7 +110,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * @param string $plugin_path Path to plugin or theme calling the framework.
 		 */
 		public function run( $plugin_path ) {
-			$config = $this->register_json_file_data( $plugin_path );
+			$config = $this->register_json_file( $plugin_path );
 			if ( ! empty( $config ) ) {
 				$this->register( $config, $plugin_path );
 			}
@@ -124,7 +124,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 *
 		 * @return bool|array $config
 		 */
-		public function register_json_file_data( $plugin_path ) {
+		public function register_json_file( $plugin_path ) {
 			$config = [];
 			if ( file_exists( $plugin_path . '/wp-dependencies.json' ) ) {
 				$config = file_get_contents( $plugin_path . '/wp-dependencies.json' );


### PR DESCRIPTION
Use separate function for registering JSON file. Further simplifies `run()`.

@Raruto this shouldn't result in any functional changes.