### PR TITLE
"get_config" abstraction 

### DIFF
--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -754,7 +754,6 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 			} else {
 				return isset( $this->config[ $slug ][ $key ] ) ? $this->config[ $slug ][ $key ] : null;
 			}
-			return null;
 		}
 
 		/**

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -749,9 +749,10 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		public function get_config( $slug = '', $key = '' ) {
 			if ( empty( $slug ) && empty( $key ) ) {
 				return $this->config;
-			}
-			if ( isset( $this->config[ $slug ] ) ) {
-				return empty( $key ) ? $this->config[ $slug ] : $this->config[ $slug ][ $key ];
+			} elseif ( empty( $key ) ) {
+				return isset( $this->config[ $slug ] ) ? $this->config[ $slug ] : false;
+			} else {
+				return isset( $this->config[ $slug ][ $key ] ) ? $this->config[ $slug ][ $key ] : false;
 			}
 			return false;
 		}

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -425,7 +425,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 			}
 
 			wp_cache_flush();
-			if ( $this->is_required( $this->config[ $slug ] ) ) {
+			if ( $this->is_required( $slug ) ) {
 				$this->activate( $slug );
 
 				return [
@@ -747,11 +747,13 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * @return mixed|array The configuration.
 		 */
 		public function get_config( $slug = '', $key = '' ) {
-			if ( isset( $this->config[ $slug ] ) ) {
-				return empty( $key ) ? $this->config[ $slug ] : $this->config[ $slug ][ $key ];
-			} else {
+			if ( empty( $slug ) && empty( $key ) ) {
 				return $this->config;
 			}
+			if ( isset( $this->config[ $slug ] ) ) {
+				return empty( $key ) ? $this->config[ $slug ] : $this->config[ $slug ][ $key ];
+			}
+			return false;
 		}
 
 		/**

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -742,11 +742,16 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 		 * @since 1.4.11
 		 *
 		 * @param string $slug Plugin slug.
+		 * @param string $key Dependency key.
 		 *
-		 * @return array The configuration.
+		 * @return mixed|array The configuration.
 		 */
-		public function get_config( $slug = '' ) {
-			return isset( $this->config[ $slug ] ) ? $this->config[ $slug ] : $this->config;
+		public function get_config( $slug = '', $key = '' ) {
+			if ( isset( $this->config[ $slug ] ) ) {
+				return empty( $key ) ? $this->config[ $slug ] : $this->config[ $slug ][ $key ];
+			} else {
+				return $this->config;
+			}
 		}
 
 		/**

--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -750,11 +750,11 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 			if ( empty( $slug ) && empty( $key ) ) {
 				return $this->config;
 			} elseif ( empty( $key ) ) {
-				return isset( $this->config[ $slug ] ) ? $this->config[ $slug ] : false;
+				return isset( $this->config[ $slug ] ) ? $this->config[ $slug ] : null;
 			} else {
-				return isset( $this->config[ $slug ][ $key ] ) ? $this->config[ $slug ][ $key ] : false;
+				return isset( $this->config[ $slug ][ $key ] ) ? $this->config[ $slug ][ $key ] : null;
 			}
-			return false;
+			return null;
 		}
 
 		/**


### PR DESCRIPTION
Related to: https://github.com/afragen/wp-dependency-installer/issues/57

Here some other possible usage examples:

```php
$config = $this->get_config( );             // Returns `[]` when no registered config.
$config = $this->get_config( $slug );       // Returns `null` on undefined slug index.
$config = $this->get_config( $slug, $key ); // Returns `null` on undefined key index.

if ( $config ) {                            // Evaluated to `false` in any cases.
}
```

Let me know if there is something wrong