### PR TITLE
lowercase host name in json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ composer require afragen/wp-dependency-installer
   },
   {
     "name": "Local Development",
-    "host": "WordPress",
+    "host": "wordpress",
     "slug": "local-development/local-development.php",
     "uri": "https://wordpress.org/plugins/local-development/",
     "required": true


### PR DESCRIPTION
I kept receiving a "[Dependency] Plugin download failed" notice and finally tracked it down to this... When host is `WordPress` it fails, but not when using lowercase `wordpress`.  Of course you could also lowercase it here - https://github.com/afragen/wp-dependency-installer/blob/develop/wp-dependency-installer.php#L204 - but that seemed overkill for now.