### PR TITLE
Updated: plugins info version

### DIFF
--- a/wp-dependency-installer.php
+++ b/wp-dependency-installer.php
@@ -258,7 +258,7 @@ if ( ! class_exists( 'WP_Dependency_Installer' ) ) {
 			$download_link = get_site_transient( 'wpdi-' . md5( $slug ) );
 
 			if ( ! $download_link ) {
-				$url           = 'https://api.wordpress.org/plugins/info/1.1/';
+				$url           = 'https://api.wordpress.org/plugins/info/1.2/';
 				$url           = add_query_arg(
 					[
 						'action'                        => 'plugin_information',


### PR DESCRIPTION
This pull request updates the API endpoint used in the `get_dot_org_latest_download` function to ensure compatibility with the latest version of the WordPress Plugins API.

API endpoint update:

* [`wp-dependency-installer.php`](diffhunk://#diff-48c06725337801080aaf374cda7993c158cbafc7119f5de15937d861e05536d3L261-R261): Changed the API version in the `$url` variable from `1.1` to `1.2` in the `get_dot_org_latest_download` function. This ensures the function interacts with the updated WordPress Plugins API.